### PR TITLE
fix(python): modify bdd+ vai conversion

### DIFF
--- a/visionai_data_format/Readme.md
+++ b/visionai_data_format/Readme.md
@@ -6,26 +6,25 @@
 ### VAI to BDD+
 
 i.e :
-`python vai_to_bdd.py -vai_src_folder ./test_data/vai_from_bdd -bdd_dest_file ./test_data/bdd_converted_2.json -company_code 101 -sequence_name test -storage_name storage_test -container_name container_test`
+`python vai_to_bdd.py --source ./test_data/vai_from_bdd --dst ./test_data/ --company-code 101 --storage-name storage_test --container-name container_test`
 
 Arguments :
-- `-vai_src_folder` : folder contains VAI format json file
-- `-bdd_dest_file`  : BDD+ format file save destination
-- `-company_code`  : company code
-- `-sequence_name`  : sequence name
-- `-storage_name`  : storage name
-- `-container_name`  : container name
+- `--src` : folder contains VAI format json file
+- `--dst`  : BDD+ format file save destination
+- `--company-code`  : company code
+- `--storage-name`  : storage name
+- `--container-name`  : container name
 
 
 ### BDD+ to VAI
 
 i.e :
-`python bdd_to_vai.py -bdd_src_file ./test_data/bdd_converted.json -vai_dest_folder ./test_data/vai_from_bdd`
+`python bdd_to_vai.py --src ./test_data/ --dst ./test_data/vai_from_bdd`
 
 Arguments :
-- `-bdd_src_file`  : path of file with BDD+ format
-- `-vai_dest_folder` : folder destination to saves VAI format files
-- `-sensor` : name of current sensor , optional, default : `camera1`
+- `--src`  : path of file with BDD+ format
+- `--dst` : folder destination to saves VAI format files
+- `--sensor` : name of current sensor , optional, default : `camera1`
 
 ## COCO
 

--- a/visionai_data_format/bdd_to_vai.py
+++ b/visionai_data_format/bdd_to_vai.py
@@ -1,49 +1,58 @@
 import argparse
 import json
 import logging
+import os
 
+from utils.common import LOGGING_DATEFMT, LOGGING_FORMAT
 from utils.converter import convert_bdd_to_vai
 from utils.validator import validate_bdd
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(
+    format=LOGGING_FORMAT,
+    level=logging.DEBUG,
+    datefmt=LOGGING_DATEFMT,
+)
 
 
-def bdd_to_vai(bdd_src_file: str, vai_dest_folder: str, sensor_name: str) -> None:
+def bdd_to_vai(
+    bdd_src_folder: str, vai_dest_folder: str, sensor_name: str, copy_image: bool
+) -> None:
     try:
-        raw_data = json.load(open(bdd_src_file))
+
+        label_file = os.path.join(bdd_src_folder, "labels.json")
+        raw_data = json.load(open(label_file))
+
         bdd_data = validate_bdd(raw_data).dict()
-        convert_bdd_to_vai(bdd_data, vai_dest_folder, sensor_name)
+        convert_bdd_to_vai(
+            bdd_src_folder, bdd_data, vai_dest_folder, sensor_name, copy_image
+        )
+
     except Exception as e:
         logger.error("Convert bdd to vai format failed : " + str(e))
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+
     parser.add_argument(
-        "-vai_dest_folder",
-        type=str,
-        required=True,
-        help="VisionAI format destination folder path",
-    )
-    parser.add_argument(
-        "-bdd_src_file",
+        "-s",
+        "--src",
         type=str,
         required=True,
         help="BDD+ format source file name (i.e : bdd_dest.json)",
     )
     parser.add_argument(
+        "-d",
+        "--dst",
+        type=str,
+        required=True,
+        help="VisionAI format destination folder path",
+    )
+    parser.add_argument(
         "--sensor", type=str, help="Sensor name, i.e : `camera1`", default="camera1"
     )
-
-    FORMAT = "%(asctime)s[%(process)d][%(levelname)s] %(name)-16s : %(message)s"
-    DATEFMT = "[%d-%m-%Y %H:%M:%S]"
-
-    logging.basicConfig(
-        format=FORMAT,
-        level=logging.DEBUG,
-        datefmt=DATEFMT,
-    )
-
+    parser.add_argument("--copy-image", action="store_true")
     args = parser.parse_args()
 
-    bdd_to_vai(args.bdd_src_file, args.vai_dest_folder, args.sensor)
+    bdd_to_vai(args.src, args.dst, args.sensor, args.copy_image)

--- a/visionai_data_format/utils/calculation.py
+++ b/visionai_data_format/utils/calculation.py
@@ -27,3 +27,30 @@ def xyxy2xywh(geometry: Dict) -> Tuple:
     y = (y1 + y2) / 2
 
     return x, y, w, h
+
+
+def gen_intervals(intervals: list[int]) -> list[Dict]:
+
+    intervals.sort()
+
+    new_intervals = [(intervals[0], intervals[0])]
+
+    for frame_num in intervals:
+        last_start, last_end = new_intervals[-1]
+        if last_start <= frame_num <= last_end:
+            continue
+        if frame_num > last_end and frame_num - last_end == 1:
+            new_intervals[-1] = (last_start, frame_num)
+        elif frame_num < last_start and last_start - frame_num == 1:
+            new_intervals[-1] = (frame_num, last_end)
+        else:
+            new_intervals.append((frame_num, frame_num))
+    interval_result_list: list[Dict] = [
+        {
+            "frame_start": start,
+            "frame_end": end,
+        }
+        for start, end in new_intervals
+    ]
+
+    return interval_result_list

--- a/visionai_data_format/utils/converter.py
+++ b/visionai_data_format/utils/converter.py
@@ -1,7 +1,9 @@
 import json
 import logging
 import os
+import shutil
 from collections import defaultdict
+from typing import Optional
 
 from schemas.bdd_schema import AtrributeSchema
 from schemas.visionai_schema import (
@@ -20,7 +22,8 @@ from schemas.visionai_schema import (
     VisionAI,
 )
 
-from .calculation import xywh2xyxy, xyxy2xywh
+from .calculation import gen_intervals, xywh2xyxy, xyxy2xywh
+from .common import BBOX_NAME, GROUND_TRUTH_FOLDER, IMAGE_EXT, VISIONAI_OBJECT_JSON
 from .validator import save_as_json, validate_vai
 
 logger = logging.getLogger(__name__)
@@ -28,24 +31,28 @@ VERSION = "00"
 
 
 def convert_vai_to_bdd(
-    folder_name: str,
+    root_folder: str,
     company_code: int,
-    sequence_name: str,
     storage_name: str,
     container_name: str,
+    bdd_dest: Optional[str] = None,
 ) -> dict:
-    if not os.path.exists(folder_name) or len(os.listdir(folder_name)) == 0:
+    if not os.path.exists(root_folder) or len(os.listdir(root_folder)) == 0:
         logger.info("[convert_vai_to_bdd] Folder empty or doesn't exits")
     else:
         logger.info("[convert_vai_to_bdd] Convert started")
 
     frame_list = list()
-    for file_name in sorted(os.listdir(folder_name)):
-        raw_data = open(os.path.join(folder_name, file_name)).read()
+    for sequence_folder in sorted(os.listdir(root_folder)):
+        annotation_path = os.path.join(
+            root_folder, sequence_folder, GROUND_TRUTH_FOLDER, VISIONAI_OBJECT_JSON
+        )
+        with open(annotation_path) as f:
+            raw_data = f.read()
         json_format = json.loads(raw_data)
         vai_data = validate_vai(json_format).visionai
         cur_frame_list = convert_vai_to_bdd_single(
-            vai_data, sequence_name, storage_name, container_name
+            vai_data, sequence_folder, storage_name, container_name, bdd_dest
         )
         frame_list += cur_frame_list
 
@@ -57,7 +64,11 @@ def convert_vai_to_bdd(
 
 
 def convert_vai_to_bdd_single(
-    vai_data: VisionAI, sequence_name: str, storage_name: str, container_name: str
+    vai_data: VisionAI,
+    sequence_name: str,
+    storage_name: str,
+    container_name: str,
+    bdd_dest: Optional[str] = None,
 ) -> list:
     cur_data = {}
     cur_data["sequence"] = sequence_name
@@ -65,8 +76,8 @@ def convert_vai_to_bdd_single(
     cur_data["dataset"] = container_name
 
     frame_list = list()
-    for frame_key, frame_data in vai_data.frames.items():
-        cur_data["name"] = frame_key + ".jpg"
+    for frame_idx, frame_data in vai_data.frames.items():
+        cur_data["name"] = f"{frame_idx}{IMAGE_EXT}"
         labels = []
         idx = 0
         for obj_id, obj_data in frame_data.objects.items():
@@ -98,83 +109,134 @@ def convert_vai_to_bdd_single(
 
         cur_data["labels"] = labels
         frame_list.append(cur_data)
+        if bdd_dest:
+            bdd_dest_image_folder = os.path.join(bdd_dest, sequence_name)
+            os.makedirs(bdd_dest_image_folder, exist_ok=True)
+            # get only the first sensor from frame_properties
+            sensor = list(frame_data.frame_properties.streams.keys())[0]
+
+            shutil.copy(
+                frame_data.frame_properties.streams[sensor].uri,
+                os.path.join(bdd_dest_image_folder, f"{frame_idx}{IMAGE_EXT}"),
+            )
+
     return frame_list
 
 
-def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -> None:
-    frame_list = bdd_data.get("frame_list", None)
+def convert_bdd_to_vai(
+    bdd_src_folder: str,
+    bdd_data: dict,
+    vai_dest_folder: str,
+    sensor_name: str,
+    copy_image: bool,
+) -> None:
+    bdd_frame_list = bdd_data.get("frame_list", None)
 
-    if not frame_list:
+    if not bdd_frame_list:
         logger.info(
             "[convert_bdd_to_vai] frame_list is empty, convert_bdd_to_vai will not be executed"
         )
         return
-
     try:
         logger.info("[convert_bdd_to_vai] Convert started ")
-        for frame in frame_list:
-            name = os.path.splitext(frame["name"])[0]
-            frame_idx = f"{int(name.split('.')[0]):012d}"
-            labels = frame["labels"]
-            meta_ds = frame.get("meta_ds", None)
-            url = meta_ds["coco_url"] if meta_ds else name
+        custom_sequence_number = 0
+
+        bdd_sequence_frame_dict = defaultdict(dict)
+        bdd_frame_file_map: dict = {}
+        for bdd_frame in bdd_frame_list:
+            sequence_num = bdd_frame["sequence"]
+            if not sequence_num.isdigit():
+                sequence_num = custom_sequence_number
+                custom_sequence_number += 1
+            else:
+                sequence_num = int(sequence_num)
+
+            frame_file_name = bdd_frame["name"]
+            frame_num = int(os.path.splitext(frame_file_name)[0])
+            labels = bdd_frame["labels"]
+            bdd_sequence_frame_dict[sequence_num][frame_num] = labels
+            bdd_frame_file_map[(sequence_num, frame_num)] = frame_file_name
+
+        for sequence_num, frame_data in bdd_sequence_frame_dict.items():
+            sequence_idx = f"{sequence_num:012d}"
+            vai_seq_folder = os.path.join(vai_dest_folder, sequence_idx)
+            vai_annot_folder = os.path.join(vai_seq_folder, GROUND_TRUTH_FOLDER)
+            os.makedirs(vai_annot_folder, exist_ok=True)
+
+            gt_frame_intervals = gen_intervals(list(frame_data.keys()))
+            frame_intervals = [
+                FrameInterval(**frame_interval) for frame_interval in gt_frame_intervals
+            ]
 
             frames: dict[str, Frame] = defaultdict(Frame)
             objects: dict[str, Object] = defaultdict(Object)
-            frame_data: Frame = Frame(
-                objects=defaultdict(ObjectData),
-                frame_properties=FrameProperties(
-                    streams={sensor_name: FramePropertyStream(uri=url)}
-                ),
-            )
-            frame_intervals = [
-                FrameInterval(frame_end=frame_idx, frame_start=frame_idx)
-            ]
 
-            if not labels:
-                logger.info(
-                    f"[convert_bdd_to_vai] No labels in this frame : {frame['name']}"
+            for frame_num, labels in frame_data.items():
+                frame_idx = f"{frame_num:012d}"
+                vai_image_folder = os.path.join(vai_seq_folder, "data", sensor_name)
+                dest_image_path = os.path.join(vai_image_folder, frame_idx + IMAGE_EXT)
+                new_frame: Frame = Frame(
+                    objects=defaultdict(ObjectData),
+                    frame_properties=FrameProperties(
+                        streams={sensor_name: FramePropertyStream(uri=dest_image_path)}
+                    ),
                 )
 
-            for label in labels:
-                # TODO: mapping attributes to the VAI
-                attributes = label["attributes"]
-                attributes.pop("cameraIndex", None)
-                attributes.pop("INSTANCE_ID", None)
-
-                category = label["category"]
-                obj_uuid = label["uuid"]
-                x, y, w, h = xyxy2xywh(label["box2d"])
-                confidence_score = label.get("meta_ds", {}).get("score", None)
-                object_under_frames = {
-                    obj_uuid: ObjectUnderFrame(
-                        object_data=ObjectData(
-                            bbox=[
-                                Bbox(
-                                    name="bbox_shape",
-                                    val=[x, y, w, h],
-                                    stream=sensor_name,
-                                    coordinate_system=sensor_name,
-                                    confidence_score=confidence_score,
-                                )
-                            ]
-                        )
+                if not labels:
+                    logger.info(
+                        f"[convert_bdd_to_vai] No labels in this sequence-frame : {sequence_idx}-{frame_idx}"
                     )
-                }
-                frame_data.objects.update(object_under_frames)
+                for label in labels:
+                    # TODO: mapping attributes to the VAI
+                    attributes = label["attributes"]
+                    attributes.pop("cameraIndex", None)
+                    attributes.pop("INSTANCE_ID", None)
 
-                objects[obj_uuid] = Object(
-                    name=category,
-                    type=category,
-                    frame_intervals=frame_intervals,
-                    object_data_pointers={
-                        "bbox_shape": ObjectDataPointer(
-                            type=ObjectType.bbox, frame_intervals=frame_intervals
+                    category = label["category"]
+                    obj_uuid = label["uuid"]
+                    x, y, w, h = xyxy2xywh(label["box2d"])
+                    confidence_score = label.get("meta_ds", {}).get("score", None)
+                    object_under_frames = {
+                        obj_uuid: ObjectUnderFrame(
+                            object_data=ObjectData(
+                                bbox=[
+                                    Bbox(
+                                        name="bbox_shape",
+                                        val=[x, y, w, h],
+                                        stream=sensor_name,
+                                        coordinate_system=sensor_name,
+                                        confidence_score=confidence_score,
+                                    )
+                                ]
+                            )
                         )
-                    },
-                )
-            frames[frame_idx] = frame_data
-            streams = {sensor_name: Stream(type=StreamType.camera)}
+                    }
+                    new_frame.objects.update(object_under_frames)
+
+                    objects[obj_uuid] = Object(
+                        name=category,
+                        type=category,
+                        frame_intervals=frame_intervals,
+                        object_data_pointers={
+                            BBOX_NAME: ObjectDataPointer(
+                                type=ObjectType.bbox, frame_intervals=frame_intervals
+                            )
+                        },
+                    )
+                frames[frame_idx] = new_frame
+
+                if copy_image:
+                    bdd_image_file = bdd_frame_file_map[(sequence_num, frame_num)]
+                    os.makedirs(vai_image_folder, exist_ok=True)
+                    dest_image_path = os.path.join(
+                        vai_image_folder, frame_idx + IMAGE_EXT
+                    )
+                    shutil.copy(
+                        os.path.join(bdd_src_folder, sequence_idx, bdd_image_file),
+                        dest_image_path,
+                    )
+
+            streams = {sensor_name: Stream(type=StreamType.camera, uri=dest_image_path)}
             coordinate_systems = {
                 sensor_name: {
                     "type": "sensor_cs",
@@ -195,8 +257,8 @@ def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -
             vai_data = validate_vai(vai_data).dict(exclude_none=True)
             save_as_json(
                 vai_data,
-                folder_name=vai_dest_folder,
-                file_name=name + ".json",
+                folder_name=vai_annot_folder,
+                file_name=VISIONAI_OBJECT_JSON,
             )
 
         logger.info("[convert_bdd_to_vai] Convert finished")

--- a/visionai_data_format/vai_to_coco.py
+++ b/visionai_data_format/vai_to_coco.py
@@ -40,7 +40,7 @@ def make_parser():
     )
     parser.add_argument(
         "-oc",
-        "--ontology_classes",
+        "--ontology-classes",
         type=str,
         default="",  # ex: 'cat,dog,horse'
         help="labels (or categories) of the training data",


### PR DESCRIPTION
## Purpose

as mentioned.
[AB#12398](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2028%20-%20Training%20Details?workitem=12398)

## What Changes?
- fix conversion between bdd+ and visionai format (accept sequential dataset between both format)
![MicrosoftTeams-image (10)](https://user-images.githubusercontent.com/94961931/216277577-58ea4dce-41c2-453d-b4c3-f561fe4eec10.png)

- add copy image option
- small refactor

## What to Check?

- It should work.

convert visionai to bdd+  :

![image](https://user-images.githubusercontent.com/94961931/216276161-9bd452cc-7466-4de1-9620-a65ec5594c7f.png)

convert bdd+ to visionai :

![image](https://user-images.githubusercontent.com/94961931/216275931-385a85f9-7d21-4eeb-8233-bbbbacd14eb2.png)

## TODO
we will update the structure of bdd+ in `dataverse` backend in the future
