### PR TITLE
fix(validators): visionai might not have tags key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.11"
+PACKAGE_VERSION = "1.0.12"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -145,17 +145,17 @@ def build_ontology_attributes_map(ontology: Ontology) -> Dict[str, Dict[str, Set
 
 
 def validate_tags_classes(
-    tags: Dict,
     ontology_classes: Set[str],
+    tags: Optional[Dict] = None,
 ) -> Tuple[str, int]:
     """verify tags under visionai data
 
     Parameters
     ----------
-    tags : Dict
-        tags under visionai data
     ontology_classes : Set[str]
         current ontology classes
+    tags : Optional[Dict]
+        tags under visionai data, could be None
 
     Returns
     -------
@@ -163,6 +163,8 @@ def validate_tags_classes(
         a tuple of validation error message and number of classes under tags
 
     """
+    if tags is None:
+        return ("", 0)
 
     if not tags:
         return ("Can't validate empty tags", -1)
@@ -196,10 +198,11 @@ def validate_tags_classes(
 
 
 def validate_tags(visionai: Dict, tags: Dict, *args, **kwargs) -> Tuple[str, int]:
+    # Validate the tags classes if the visionai contains this key
     ontology_classes: Set[str] = set(tags.keys())
 
     return validate_tags_classes(
-        tags=visionai["tags"], ontology_classes=ontology_classes
+        tags=visionai.get("tags"), ontology_classes=ontology_classes
     )
 
 


### PR DESCRIPTION
## Purpose
The current code expects the `visionai` to have `tags` to be validated, which is not always right.

## Root cause
When validating the visionai without tags key, calling `visionai["tags"]` caused the `KeyError`.
![image](https://github.com/linkervision/visionai-data-format/assets/20389114/f0291453-28f4-4594-bf6e-26a400bc38d3)

## What Changes?
- Adjust the `tags` parameter to be optional in `validate_tags_classes`.
- Pass `visionai.get("tags")` to `validate_tags_classes` instead of `visionai["tags"]`.
- Update version from `1.0.11` to `1.0.12`

## What to Check?

- Validate visionai without tags key by `validate_tags_classes` shouldn't raise the `KeyError`.
