### PR TITLE
fix(python): order of pydantic union type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.3.1"
+PACKAGE_VERSION = "1.3.2"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/schemas/ontology.py
+++ b/visionai_data_format/schemas/ontology.py
@@ -21,7 +21,7 @@ class AttributeType(str, Enum):
 
 class Attribute(BaseModel):
     type: AttributeType
-    value: Optional[List[Union[float, str, int]]] = None
+    value: Optional[List[Union[str, int, float]]] = None
 
     class Config:
         use_enum_values = True

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -291,7 +291,7 @@ class VecBaseNoName(ExcludedNoneBaseModel):
         description="This attribute specifies whether the vector shall be"
         + " considered as a descriptor of individual values or as a definition of a range.",
     )
-    val: List[Union[float, int, str]] = Field(
+    val: List[Union[str, int, float]] = Field(
         ..., description="The values of the vector (list)."
     )
 


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
As title.

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#19691](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/19691)

## Root Cause

<!-- If the PR is bug fix, please provide the root cause of the bug -->
- The pydantic model will check the union data type as the orders.
( previously '240315' was converted to 240315.0)
https://stackoverflow.com/questions/70399568/pydantic-model-field-of-type-unionint-float-how-to-prevent-field-from-round

## What Changes?
<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- change the union type order to [str, int, float]

## What to Check?
Will work as expected.
![image](https://github.com/linkervision/visionai-data-format/assets/55373569/662e7eb3-eac5-4ed3-b27b-3d7f6eec2eb1)

