### PR TITLE
feat(python): convert yolo format data to visionai format and little fix for coco <-> visionai

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,13 +628,6 @@ Arguments :
 - `-img_width` : image width for all images (default: None, which will read the image and get the size)
 
 
-
-
-
-
-
-
-
 ## Troubleshooting
 
 (WIP)

--- a/README.md
+++ b/README.md
@@ -628,6 +628,23 @@ Arguments :
 - `-img_width` : image width for all images (default: None, which will read the image and get the size)
 
 
+* The `YOLO` dataset should follow the data structure as below:
+```bash
+.yolo-format-root_folder
+├── classes.txt
+├── images
+│   ├── 000000.png
+│   ├── 000001.png
+│   ├── 000002.png
+│   └── 000003.png
+├── labels
+│   ├── 000000.txt
+│   ├── 000001.txt
+│   ├── 000002.txt
+│   ├── 000003.txt
+```
+
+
 ## Troubleshooting
 
 (WIP)

--- a/README.md
+++ b/README.md
@@ -569,7 +569,6 @@ Arguments :
 
 ```
 python3 visionai_data_format/convert_dataset.py -input_format coco -output_format vision_ai -image_annotation_type 2d_bounding_box -input_annotation_path ./coco_instance.json -source_data_root ./coco_images/ -output_dest_folder ~/visionai_output_dir -uri_root http://storage_test -n_frame 5 -sequence_idx_start 0 -camera_sensor_name camera1 -annotation_name groundtruth -img_extension .jpg --copy_sensor_data
-
 ```
 
 Arguments :
@@ -591,7 +590,6 @@ Arguments :
 
 ```
 python3 visionai_data_format/convert_dataset.py -input_format vision_ai -output_format coco -image_annotation_type 2d_bounding_box -source_data_root ./visionai_data_root -output_dest_folder ~/coco_output_dir -uri_root http://storage_test -n_frame 5 -camera_sensor_name camera1 -annotation_name groundtruth -img_extension .jpg --copy_sensor_data
-
 ```
 Arguments :
 - `-input_format`  : input format (vision_ai)

--- a/README.md
+++ b/README.md
@@ -604,6 +604,37 @@ Arguments :
 - `-img_extension` : image file extension (default: ".jpg")
 - `--copy_sensor_data` : enable to copy image data
 
+### Convert `YOLO` format data to `VisionAI` format
+
+```
+python3 visionai_data_format/convert_dataset.py -input_format yolo -output_format vision_ai -image_annotation_type 2d_bounding_box -source_data_root ./path_to_yolo_format_dir -output_dest_folder ./output_visionai_dir -n_frame -1 -sequence_idx_start 0 -uri_root http://storage_test -camera_sensor_name camera1 -annotation_name groundtruth -img_extension .jpg  --copy_sensor_data -classes_file category.txt
+```
+
+Arguments :
+- `-input_format`  : input format (use yolo for YOLO format)
+- `-output_format`  : output format (vision_ai)
+- `-image_annotation_type`  : label annotation type for image (2d_bounding_box for box2D)
+- `-source_data_root`  : data root folder of yolo format
+- `-output_dest_folder` : output root folder (VisionAI local root folder)
+- `-uri_root` : uri root for target upload VisionAI storage i.e: https://azuresorate/vai_dataset
+- `-n_frame`  : number of frame to be converted (-1 means all), by default -1
+- `-sequence_idx_start `  : sequence start id, by default 0
+- `-camera_sensor_name`  : camera sensor name (default: "", specified it if need to convert camera data)
+- `-annotation_name` : VisionAI annotation folder name (default: "groundtruth")
+- `-img_extension` : image file extension (default: ".jpg")
+- `--copy_sensor_data` : enable to copy image data
+- `-classes_file` : txt file contain category names in each line, by default "classes.txt"
+- `-img_height` : image height for all images (default: None, which will read the image and get the size)
+- `-img_width` : image width for all images (default: None, which will read the image and get the size)
+
+
+
+
+
+
+
+
+
 ## Troubleshooting
 
 (WIP)

--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ Arguments :
 - `-input_format`  : input format (use coco for COCO format)
 - `-output_format`  : output format (vision_ai)
 - `-image_annotation_type`  : label annotation type for image (2d_bounding_box for box2D)
+- `-input_annotation_path` : input annotation path for coco-label.json file
 - `-source_data_root`  : image data folder
 - `-output_dest_folder` : output root folder (VisionAI local root folder)
 - `-uri_root` : uri root for target upload VisionAI storage i.e: https://azuresorate/vai_dataset

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
 PACKAGE_VERSION = "1.4.0"
 DESC = "converter tool for visionai format"
-REQUIRED = ["pydantic==1.*"]
+REQUIRED = ["pydantic==1.*", "pillow"]
 REQUIRES_PYTHON = ">=3.7, <4"
 EXTRAS = {
     "test": [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.4.0"
+PACKAGE_VERSION = "1.3.3"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*", "pillow"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.3.2"
+PACKAGE_VERSION = "1.4.0"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/convert_dataset.py
+++ b/visionai_data_format/convert_dataset.py
@@ -26,6 +26,9 @@ class DatasetConverter:
         annotation_name: str = "groundtruth",
         img_extension: str = ".jpg",
         ontology_classes: str = "",
+        classes_file_name: str = "classes.txt",
+        img_height: Optional[int] = None,
+        img_width: Optional[int] = None,
     ):
         """Run Dataset Converter
 
@@ -55,6 +58,11 @@ class DatasetConverter:
             output annotation name, by default "groundtruth"
         img_extension : str, optional
             img file extension, by default ".jpg"
+        ontology_classes: str
+        classes_file_name: str = "classes.txt",
+        img_height: int, optional
+        img_width: int, optional
+
 
         Raises
         ------
@@ -84,6 +92,9 @@ class DatasetConverter:
             annotation_name=annotation_name,
             img_extension=img_extension,
             ontology_classes=ontology_classes,
+            classes_file_name=classes_file_name,
+            img_height=img_height,
+            img_width=img_width,
         )
 
 
@@ -107,7 +118,6 @@ if __name__ == "__main__":
         required=True,
         help="2d_bounding_box",
     )
-
     parser.add_argument(
         "-input_annotation_path",
         type=str,
@@ -138,7 +148,6 @@ if __name__ == "__main__":
         help="Camera Sensor name, i.e : `camera1`",
         default="",
     )
-
     parser.add_argument(
         "-lidar_sensor_name",
         type=str,
@@ -148,7 +157,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "-sequence_idx_start", type=int, help="sequence id start number", default=0
     )
-
     parser.add_argument(
         "-annotation_name",
         type=str,
@@ -162,6 +170,18 @@ if __name__ == "__main__":
         help="image extention (default: .jpg)",
     )
     parser.add_argument(
+        "-img_width",
+        type=int,
+        required=False,
+        help="image width",
+    )
+    parser.add_argument(
+        "-img_height",
+        type=int,
+        required=False,
+        help="image height",
+    )
+    parser.add_argument(
         "-n_frame",
         type=int,
         help="target convert frame number, -1 means all",
@@ -172,6 +192,12 @@ if __name__ == "__main__":
         type=str,
         default="",
         help="','.join(ontology_classes_list), add this if we required category id follow the specified order ",
+    )
+    parser.add_argument(
+        "-classes_file",
+        type=str,
+        default="classes.txt",
+        help="file for store category names for yolo format",
     )
     parser.add_argument(
         "--copy_sensor_data",
@@ -191,7 +217,6 @@ if __name__ == "__main__":
 
     if not args.camera_sensor_name and not args.lidar_sensor_name:
         raise VisionAIException(error_code=VisionAIErrorCode.VAI_ERR_002)
-
     DatasetConverter.run(
         input_format=args.input_format,
         output_format=args.output_format,
@@ -208,4 +233,7 @@ if __name__ == "__main__":
         n_frame=args.n_frame,
         copy_sensor_data=args.copy_sensor_data,
         ontology_classes=args.ontology_classes,
+        classes_file_name=args.classes_file,
+        img_width=args.img_width,
+        img_height=args.img_height,
     )

--- a/visionai_data_format/convert_dataset.py
+++ b/visionai_data_format/convert_dataset.py
@@ -58,8 +58,8 @@ class DatasetConverter:
             output annotation name, by default "groundtruth"
         img_extension : str, optional
             img file extension, by default ".jpg"
-        ontology_classes: str
-        classes_file_name: str = "classes.txt",
+        ontology_classes: str, by default: ""
+        classes_file_name: str, by default: "classes.txt",
         img_height: int, optional
         img_width: int, optional
 

--- a/visionai_data_format/converters/__init__.py
+++ b/visionai_data_format/converters/__init__.py
@@ -4,3 +4,4 @@ from .bdd_to_vai import __all__
 from .coco_to_vai import __all__
 from .kitti_to_vai import __all__
 from .vai_to_coco import __all__
+from .yolo_to_vai import __all__

--- a/visionai_data_format/converters/coco_to_vai.py
+++ b/visionai_data_format/converters/coco_to_vai.py
@@ -92,19 +92,28 @@ class COCOtoVAI(Converter):
                 logger.info(
                     f"convert sequence {old_sequence_idx} to {dest_sequence_name}"
                 )
-                cls.convert_coco_to_vai(
+                vai_data = cls.convert_coco_to_vai(
                     image_data=image_data,
                     img_name_id_map=img_name_id_map,
                     vai_dest_folder=output_dest_folder,
                     camera_sensor_name=camera_sensor_name,
                     dest_sequence_name=dest_sequence_name,
                     uri_root=uri_root,
-                    annotation_name=annotation_name,
                     img_extension=img_extension,
                     copy_sensor_data=copy_sensor_data,
                     source_data_root=source_data_root,
                     class_id_name_map=class_id_name_map,
                     img_id_annotations_map=img_id_annotations_map,
+                )
+                save_as_json(
+                    vai_data,
+                    folder_name=os.path.join(
+                        output_dest_folder,
+                        dest_sequence_name,
+                        "annotations",
+                        annotation_name,
+                    ),
+                    file_name="visionai.json",
                 )
                 if n_frame == 0:
                     break
@@ -134,10 +143,9 @@ class COCOtoVAI(Converter):
         source_data_root: str,
         class_id_name_map: dict[str, str],
         img_id_annotations_map: dict[str, list[dict]],
-        annotation_name: str = "groundtruth",
         img_extension: str = ".jpg",
         copy_sensor_data: bool = True,
-    ) -> None:
+    ) -> dict:
         try:
             image_file_name = image_data["file_name"]
             image_file_path = os.path.join(source_data_root, image_file_name)
@@ -238,15 +246,7 @@ class COCOtoVAI(Converter):
                 vai_data["visionai"].pop("objects")
 
             vai_data = validate_vai(vai_data).dict(exclude_none=True)
-
-            save_as_json(
-                vai_data,
-                folder_name=os.path.join(
-                    vai_dest_folder, dest_sequence_name, "annotations", annotation_name
-                ),
-                file_name="visionai.json",
-            )
-
             logger.info("[convert_coco_to_vai] Convert finished")
+            return vai_data
         except Exception as e:
             logger.error("[convert_coco_to_vai] Convert failed : " + str(e))

--- a/visionai_data_format/converters/vai_to_coco.py
+++ b/visionai_data_format/converters/vai_to_coco.py
@@ -12,8 +12,8 @@ from visionai_data_format.schemas.common import AnnotationFormat, OntologyImageT
 from visionai_data_format.utils.classes import gen_ontology_classes_dict
 from visionai_data_format.utils.common import (
     ANNOT_PATH,
+    COCO_IMAGE_PATH,
     COCO_LABEL_FILE,
-    DATA_PATH,
     IMAGE_EXT,
     VISIONAI_JSON,
 )
@@ -65,7 +65,7 @@ class VAItoCOCO(Converter):
 
         logger.info("retrieve visionai annotations finished")
 
-        dest_img_folder = os.path.join(output_dest_folder, DATA_PATH)
+        dest_img_folder = os.path.join(output_dest_folder, COCO_IMAGE_PATH)
         dest_json_folder = os.path.join(output_dest_folder, ANNOT_PATH)
         if copy_sensor_data:
             # create {dest}/data folder #

--- a/visionai_data_format/converters/vai_to_coco.py
+++ b/visionai_data_format/converters/vai_to_coco.py
@@ -52,6 +52,11 @@ class VAItoCOCO(Converter):
         visionai_dict_list = []
         logger.info("retrieve visionai annotations started")
         for sequence in sequence_folder_list:
+            if not os.path.isdir(os.path.join(source_data_root, sequence)):
+                logger.info(
+                    f"file {sequence} is ignore since it is not a sequence folder"
+                )
+                continue
             annotation_path = os.path.join(
                 source_data_root,
                 sequence,
@@ -154,7 +159,9 @@ class VAItoCOCO(Converter):
         for frame_data in visionai_dict["visionai"]["frames"].values():
             if len(images) == n_frame:
                 break
-            dest_coco_url = os.path.join(uri_root, f"{image_id:012d}{img_extension}")
+            dest_coco_url = os.path.join(
+                uri_root, COCO_IMAGE_PATH, f"{image_id:012d}{img_extension}"
+            )
             dest_coco_img = os.path.join(
                 dest_img_folder, f"{image_id:012d}{img_extension}"
             )

--- a/visionai_data_format/converters/yolo_to_vai.py
+++ b/visionai_data_format/converters/yolo_to_vai.py
@@ -53,11 +53,10 @@ class YOLOtoVAI(Converter):
     @classmethod
     def convert(
         cls,
-        output_dest_folder: str,
         camera_sensor_name: str,
         source_data_root: str,
+        output_dest_folder: str,
         uri_root: str,
-        classes_file_name: str = "classes.txt",
         sequence_idx_start: int = 0,
         copy_sensor_data: bool = True,
         n_frame: int = -1,
@@ -65,13 +64,41 @@ class YOLOtoVAI(Converter):
         img_extension: str = ".jpg",
         img_height: Optional[int] = None,
         img_width: Optional[int] = None,
+        classes_file_name: str = "classes.txt",
         **kwargs,
     ) -> None:
+        """convert yolo format data to visionai data format
+
+        Parameters
+        ----------
+        camera_sensor_name : str
+        source_data_root : str
+            data root folder of yolo format
+        output_dest_folder : str
+        uri_root : str
+            uri root for target upload VisionAI
+        sequence_idx_start : int, optional
+            sequence start id, by default 0
+        copy_sensor_data : bool, optional
+            enable to copy image data, by default True
+        n_frame : int, optional
+            number of frame to be converted (-1 means all), by default -1
+        annotation_name : str, optional
+            VisionAI annotation folder name , by default "groundtruth"
+        img_extension : str, optional
+            image file extension, by default ".jpg"
+        img_height : Optional[int], optional
+            image height for all images, by default None
+        img_width : Optional[int], optional
+            image width for all images, by default None
+        classes_file_name : str, optional
+            txt file contain category names in each line, by default "classes.txt"
+        """
         try:
             classes_file_path = os.path.join(source_data_root, classes_file_name)
             if not Path(classes_file_path).exists():
                 raise FileNotFoundError(
-                    "Please ensure your classes file is under source data root"
+                    "Please ensure your classes txt file is under source data root"
                 )
             with open(classes_file_path) as classes_file:
                 classes_list: list = [line.strip() for line in classes_file]

--- a/visionai_data_format/converters/yolo_to_vai.py
+++ b/visionai_data_format/converters/yolo_to_vai.py
@@ -1,0 +1,239 @@
+import logging
+import os
+import shutil
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from visionai_data_format.converters.base import Converter, ConverterFactory
+from visionai_data_format.exceptions import VisionAIErrorCode, VisionAIException
+from visionai_data_format.schemas.common import AnnotationFormat, OntologyImageType
+from visionai_data_format.schemas.visionai_schema import (
+    Bbox,
+    DynamicObjectData,
+    Frame,
+    FrameInterval,
+    FrameProperties,
+    FramePropertyStream,
+    Object,
+    ObjectDataPointer,
+    ObjectType,
+    ObjectUnderFrame,
+    Stream,
+    StreamType,
+)
+from visionai_data_format.utils.validator import save_as_json, validate_vai
+
+__all__ = ["YOLOtoVAI"]
+
+logger = logging.getLogger(__name__)
+
+YOLO_IMAGE_FOLDER = "images"
+YOLO_LABEL_FOLDER = "labels"
+
+
+@ConverterFactory.register(
+    from_=AnnotationFormat.YOLO,
+    to_=AnnotationFormat.VISION_AI,
+    image_annotation_type=OntologyImageType._2D_BOUNDING_BOX,
+)
+class YOLOtoVAI(Converter):
+    @staticmethod
+    def nxywh2xywh(obj, img_w, img_h):
+        x = int(obj[0] * img_w)
+        y = int(obj[1] * img_h)
+        w = int(obj[2] * img_w)
+        h = int(obj[3] * img_h)
+
+        return x, y, w, h
+
+    @classmethod
+    def convert(
+        cls,
+        input_annotation_path: str,
+        output_dest_folder: str,
+        camera_sensor_name: str,
+        source_data_root: str,
+        uri_root: str,
+        classes_file_name: str = "classes.txt",
+        lidar_sensor_name: Optional[str] = None,
+        sequence_idx_start: int = 0,
+        copy_sensor_data: bool = True,
+        n_frame: int = -1,
+        annotation_name: str = "groundtruth",
+        img_extension: str = ".jpg",
+        **kwargs,
+    ) -> None:
+        try:
+            classes_file_path = os.path.join(source_data_root, classes_file_name)
+            if not Path(classes_file_path).exists():
+                raise FileNotFoundError(
+                    "Please ensure your classes file is under source data root"
+                )
+            with open(classes_file_path) as classes_file:
+                classes_list: list = [line.strip() for line in classes_file]
+            image_folder_path = Path(source_data_root) / YOLO_IMAGE_FOLDER
+            annotation_folder = Path(source_data_root) / YOLO_LABEL_FOLDER
+
+            image_file_paths = image_folder_path.rglob("*.jpg")
+            image_file_paths += image_folder_path.rglob("*.png")
+            image_file_paths += image_folder_path.rglob("*.jpeg")
+
+            for sequence_idx, img_file in enumerate(
+                image_file_paths, sequence_idx_start
+            ):
+                if n_frame > 0:
+                    n_frame -= 1
+                annotation_path = annotation_folder / f"{img_file.stem}.txt"
+                # The image may not have any applicable annotation txt file.
+                if annotation_path.exists():
+                    with open(str(annotation_path)) as anno_file:
+                        label_list: list = [line.strip() for line in anno_file]
+                else:
+                    logging.info(
+                        f"{str(img_file)} has not mapping annotation file and is consider as an empty image."
+                    )
+                    label_list = []
+                dest_sequence_name = f"{sequence_idx:012d}"
+                h, w = (720, 1280)
+                vai_data = cls.convert_yolo_label_vai(
+                    image_file_path=str(img_file),
+                    label_list=label_list,
+                    img_height=h,
+                    img_width=w,
+                    vai_dest_folder=output_dest_folder,
+                    classes_list=classes_list,
+                    camera_sensor_name=camera_sensor_name,
+                    dest_sequence_name=dest_sequence_name,
+                    uri_root=uri_root,
+                    img_extension=img_extension,
+                    copy_sensor_data=copy_sensor_data,
+                )
+
+                save_as_json(
+                    vai_data,
+                    folder_name=os.path.join(
+                        output_dest_folder,
+                        dest_sequence_name,
+                        "annotations",
+                        annotation_name,
+                    ),
+                    file_name="visionai.json",
+                )
+                if n_frame == 0:
+                    break
+
+        except VisionAIException:
+            logger.exception("Convert coco to vai format error")
+            raise VisionAIException(
+                error_code=VisionAIErrorCode.VAI_ERR_041,
+                message_kwargs={
+                    "original_format": "YOLO",
+                    "destination_format": "VisionAI",
+                },
+            )
+
+        except Exception:
+            logger.exception("Convert yolo to vai failed")
+            raise VisionAIException(error_code=VisionAIErrorCode.VAI_ERR_999)
+
+    @classmethod
+    def convert_yolo_label_vai(
+        cls,
+        image_file_path: str,
+        label_list: list,
+        classes_list: list,
+        img_height: int,
+        img_width: int,
+        vai_dest_folder: str,
+        camera_sensor_name: str,
+        dest_sequence_name: str,
+        uri_root: str,
+        img_extension: str = ".jpg",
+        copy_sensor_data: bool = True,
+    ) -> dict:
+        try:
+            frames = {}
+            objects = {}
+            frame_intervals = []
+            frame_num = f"{0:012d}"
+            bbox_name = "bbox_shape"
+
+            dest_camera_folder = os.path.join(
+                vai_dest_folder, dest_sequence_name, "data", camera_sensor_name
+            )
+            dest_camera_path = os.path.join(
+                dest_camera_folder, frame_num + img_extension
+            )
+            if copy_sensor_data:
+                os.makedirs(dest_camera_folder, exist_ok=True)
+                shutil.copy2(image_file_path, dest_camera_path)
+
+            camera_url = os.path.join(uri_root, dest_camera_path)
+
+            # generate frames below visionai
+            frames[frame_num] = Frame(
+                frame_properties=FrameProperties(
+                    streams={camera_sensor_name: FramePropertyStream(uri=camera_url)}
+                ),
+                objects={},
+            )
+            streams = {camera_sensor_name: Stream(type=StreamType.CAMERA)}
+            frame_intervals = [FrameInterval(frame_start=0, frame_end=0)]
+            # parse yolo-labels
+            for obj_idx, label in enumerate(label_list):
+                object_id = str(uuid.uuid4())
+                label_items = label.split()
+                # yolo format [class_id, center x, center y, width, height]
+                class_id = int(label_items[0])
+                obj = [float(loc) for loc in label_items[1:]]
+
+                bbox = cls.nxywh2xywh(obj=obj, img_h=img_height, img_w=img_width)
+
+                objects_under_frames = {
+                    object_id: ObjectUnderFrame(
+                        object_data=DynamicObjectData(
+                            bbox=[
+                                Bbox(
+                                    name=bbox_name,
+                                    val=bbox,
+                                    stream=camera_sensor_name,
+                                )
+                            ]
+                        )
+                    )
+                }
+                frames[frame_num].objects.update(objects_under_frames)
+
+                # to vision_ai: objects
+                object_under_vai = {
+                    object_id: Object(
+                        name=f"{classes_list[class_id]}_{obj_idx}",
+                        type=classes_list[class_id],
+                        frame_intervals=frame_intervals,
+                        object_data_pointers={
+                            bbox_name: ObjectDataPointer(
+                                type=ObjectType.BBOX,
+                                frame_intervals=frame_intervals,
+                            )
+                        },
+                    )
+                }
+                objects.update(object_under_vai)
+
+            vai_data = {
+                "visionai": {
+                    "frame_intervals": frame_intervals,
+                    "objects": objects,
+                    "frames": frames,
+                    "streams": streams,
+                    "metadata": {"schema_version": "1.0.0"},
+                }
+            }
+            if not objects:
+                vai_data["visionai"].pop("objects")
+            vai_data = validate_vai(vai_data).dict(exclude_none=True)
+            logger.info("[convert_yolo_to_vai] Convert finished")
+            return vai_data
+        except Exception as e:
+            logger.error("[convert_yolo_to_vai] Convert failed : " + str(e))

--- a/visionai_data_format/converters/yolo_to_vai.py
+++ b/visionai_data_format/converters/yolo_to_vai.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import uuid
 from pathlib import Path
-from typing import Optional
 
 from visionai_data_format.converters.base import Converter, ConverterFactory
 from visionai_data_format.exceptions import VisionAIErrorCode, VisionAIException
@@ -30,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 YOLO_IMAGE_FOLDER = "images"
 YOLO_LABEL_FOLDER = "labels"
+IMAGE_EXTS = ["jpg", ".jpeg", ".png"]
 
 
 @ConverterFactory.register(
@@ -50,13 +50,11 @@ class YOLOtoVAI(Converter):
     @classmethod
     def convert(
         cls,
-        input_annotation_path: str,
         output_dest_folder: str,
         camera_sensor_name: str,
         source_data_root: str,
         uri_root: str,
         classes_file_name: str = "classes.txt",
-        lidar_sensor_name: Optional[str] = None,
         sequence_idx_start: int = 0,
         copy_sensor_data: bool = True,
         n_frame: int = -1,
@@ -75,10 +73,10 @@ class YOLOtoVAI(Converter):
             image_folder_path = Path(source_data_root) / YOLO_IMAGE_FOLDER
             annotation_folder = Path(source_data_root) / YOLO_LABEL_FOLDER
 
-            image_file_paths = image_folder_path.rglob("*.jpg")
-            image_file_paths += image_folder_path.rglob("*.png")
-            image_file_paths += image_folder_path.rglob("*.jpeg")
-
+            image_file_paths = []
+            # Get image files
+            for img_ext in IMAGE_EXTS:
+                image_file_paths += list(image_folder_path.rglob(f"*{img_ext}"))
             for sequence_idx, img_file in enumerate(
                 image_file_paths, sequence_idx_start
             ):

--- a/visionai_data_format/converters/yolo_to_vai.py
+++ b/visionai_data_format/converters/yolo_to_vai.py
@@ -3,6 +3,9 @@ import os
 import shutil
 import uuid
 from pathlib import Path
+from typing import Optional
+
+from PIL import Image
 
 from visionai_data_format.converters.base import Converter, ConverterFactory
 from visionai_data_format.exceptions import VisionAIErrorCode, VisionAIException
@@ -60,6 +63,8 @@ class YOLOtoVAI(Converter):
         n_frame: int = -1,
         annotation_name: str = "groundtruth",
         img_extension: str = ".jpg",
+        img_height: Optional[int] = None,
+        img_width: Optional[int] = None,
         **kwargs,
     ) -> None:
         try:
@@ -93,12 +98,15 @@ class YOLOtoVAI(Converter):
                     )
                     label_list = []
                 dest_sequence_name = f"{sequence_idx:012d}"
-                h, w = (720, 1280)
+                if not img_height or not img_width:
+                    img = Image.open(str(img_file))
+                    img_width, img_height = img.size
+
                 vai_data = cls.convert_yolo_label_vai(
                     image_file_path=str(img_file),
                     label_list=label_list,
-                    img_height=h,
-                    img_width=w,
+                    img_height=img_height,
+                    img_width=img_width,
                     vai_dest_folder=output_dest_folder,
                     classes_list=classes_list,
                     camera_sensor_name=camera_sensor_name,

--- a/visionai_data_format/schemas/common.py
+++ b/visionai_data_format/schemas/common.py
@@ -39,6 +39,7 @@ class AnnotationFormat(str, Enum, metaclass=BaseEnumMeta):
     BDDP = "bddp"
     IMAGE = "image"
     KITTI = "kitti"
+    YOLO = "yolo"
 
 
 class DatasetType(str, Enum, metaclass=BaseEnumMeta):

--- a/visionai_data_format/utils/common.py
+++ b/visionai_data_format/utils/common.py
@@ -1,5 +1,5 @@
 ANNOT_PATH = "annotations"
-DATA_PATH = "data"
+COCO_IMAGE_PATH = "images"
 GROUND_TRUTH_FOLDER = "annotations/groundtruth/"
 BBOX_NAME = "bbox_shape"
 IMAGE_EXT = ".jpg"


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
As title

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#20168](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/20168)
- [AB#19895](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/19895)

## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- Add YOLO to Visionai converter and adjust the base converter interface
- Refactor coco to visionai (save json outside the base function)
- Little fix for coco image folder name.
- update README

## What to Check?

<!-- Describe steps to verify the functions of this PR -->
- The converter could work as below
<img width="734" alt="image" src="https://github.com/linkervision/visionai-data-format/assets/55373569/11136c33-20af-4acc-93a3-f8064a70e9e5">


