### PR TITLE
fix(python): update image-id after annotation are added

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.3.4"
+PACKAGE_VERSION = "1.3.5"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*", "pillow"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/converters/vai_to_coco.py
+++ b/visionai_data_format/converters/vai_to_coco.py
@@ -193,8 +193,8 @@ class VAItoCOCO(Converter):
             )
             images.append(image)
 
-            image_id += 1
             if not frame_data.get("objects", None):
+                image_id += 1
                 continue
 
             for object_id, object_v in frame_data["objects"].items():
@@ -222,6 +222,7 @@ class VAItoCOCO(Converter):
                 )
                 annotations.append(annotation)
                 anno_id += 1
+            image_id += 1
         if n_frame != -1:
             n_frame -= len(images)
         return (category_map, images, annotations, image_id, anno_id, n_frame)


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
For image with annotations, we should update after annotations are added.

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#20515](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/20515)


## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- Fix update image-id

## What to Check?
